### PR TITLE
Add database connection manager helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
             <artifactId>mysql-connector-j</artifactId>
             <version>8.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -45,6 +51,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/napier/semGROUP4/App.java
+++ b/src/main/java/com/napier/semGROUP4/App.java
@@ -1,82 +1,26 @@
 package com.napier.semGROUP4;
-import java.sql.*;
+
 public class App {
 
-    // initializing the connection to null
-    private Connection con = null;
+    private final DatabaseConnectionManager databaseConnectionManager;
 
-    // connect to database method TODO: create a class that handles utilities
-    public void connectDB() {
-
-        // tries to load sql driver for job
-        try {
-            Class.forName("com.mysql.cj.jdbc.Driver");
-        }
-        catch (ClassNotFoundException e) {
-            System.out.println("Could not load SQL driver");
-            System.exit(-1);
-        }
-        // number of times app should try to connect to database
-        int retries = 30;
-
-        // loop for trying to connect to database
-        // TODO: this method is a copy paste from our lab3, we should plan a method that just keeps the connection open
-        for (int i = 0; i < retries; i++) {
-            System.out.println("Trying to connect to database...");
-
-            try {
-
-                // waits 3 seconds before trying to assign connection
-                Thread.sleep(3000);
-
-                // assigns user and password to connection to connect to database
-                con = DriverManager.getConnection("jdbc:mysql://db:3306/world?allowPublicKeyRetrieval=true&useSSL=false", "root", "semgroup4");
-                System.out.println("Connected to database!");
-
-                // wait 100ms to exit this trial
-                Thread.sleep(100);
-            }
-            catch (SQLException sqle) {
-                System.out.println("Failed to connect to database attempt " + i);
-            }
-            catch (InterruptedException ie) {
-                System.out.println("Interrupted? Check code.");
-            }
-        }
+    public App(DatabaseConnectionManager databaseConnectionManager) {
+        this.databaseConnectionManager = databaseConnectionManager;
     }
 
-
-    // close database connection method
-    // TODO: as with our connection method, we should move this into a class that handle utilities
-    public void closeDB() {
-
-        // if our connection is null we try to close it
-        if (con != null) {
-            try {
-                con.close();
-            }
-            catch (Exception e)
-            {
-                System.out.println("Error closing connection " + e);
-            }
-        }
+    public void run() {
+        databaseConnectionManager.connect();
+        // TODO: Add application logic that uses databaseConnectionManager.getConnection().
     }
 
     public static void main(String[] args) {
-
-        // TODO: create a menu to pass user inputs to fetch from our database
-
-        // logs app initialisation
         System.out.println("Initialising app...");
 
-        // creates an app object to start our methods
-        // TODO: since the methods should have their own class, we will need to change the object for that new class
-        App a = new App();
-
-        // call connectDB method on our app
-        a.connectDB();
-
-        // call closeDB method on our app
-        a.closeDB();
+        try (DatabaseConnectionManager connectionManager = DatabaseConnectionManager.fromEnvironment()) {
+            App application = new App(connectionManager);
+            application.run();
+        } catch (IllegalStateException ex) {
+            System.err.println("Application failed to connect to the database: " + ex.getMessage());
+        }
     }
 }

--- a/src/main/java/com/napier/semGROUP4/DatabaseConnectionManager.java
+++ b/src/main/java/com/napier/semGROUP4/DatabaseConnectionManager.java
@@ -1,0 +1,282 @@
+package com.napier.semGROUP4;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Centralised manager for establishing and closing database connections.
+ * Designed to encapsulate retry behaviour, configuration, and driver management.
+ */
+public final class DatabaseConnectionManager implements AutoCloseable {
+
+    private static final Logger LOGGER = Logger.getLogger(DatabaseConnectionManager.class.getName());
+    private static final AtomicBoolean DRIVER_LOADED = new AtomicBoolean(false);
+
+    private static final String DEFAULT_JDBC_URL =
+            "jdbc:mysql://db:3306/world?allowPublicKeyRetrieval=true&useSSL=false";
+    private static final String DEFAULT_USERNAME = "root";
+    private static final String DEFAULT_PASSWORD = "semgroup4";
+    private static final int DEFAULT_RETRY_ATTEMPTS = 10;
+    private static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(3);
+
+    private final String jdbcUrl;
+    private final String username;
+    private final String password;
+    private final int retryAttempts;
+    private final Duration retryDelay;
+    private Connection connection;
+
+    private DatabaseConnectionManager(Builder builder) {
+        this.jdbcUrl = builder.jdbcUrl;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.retryAttempts = builder.retryAttempts;
+        this.retryDelay = builder.retryDelay;
+    }
+
+    /**
+     * Creates a builder pre-populated with sensible defaults.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a manager using environment variables with fallbacks to defaults.
+     */
+    public static DatabaseConnectionManager fromEnvironment() {
+        Builder builder = builder()
+                .withUrl(resolveJdbcUrl())
+                .withUsername(envOrDefault("DB_USER", DEFAULT_USERNAME))
+                .withPassword(envOrDefault("DB_PASSWORD", DEFAULT_PASSWORD));
+
+        builder.withRetryAttempts(parsePositiveInt("DB_RETRY_ATTEMPTS", DEFAULT_RETRY_ATTEMPTS));
+        builder.withRetryDelay(Duration.ofMillis(parsePositiveLong("DB_RETRY_DELAY_MS",
+                DEFAULT_RETRY_DELAY.toMillis())));
+
+        return builder.build();
+    }
+
+    /**
+     * Obtains an open connection, retrying according to configuration if necessary.
+     *
+     * @return A live JDBC connection.
+     * @throws IllegalStateException if the connection cannot be established.
+     */
+    public synchronized Connection connect() {
+        loadDriverIfRequired();
+
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return connection;
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.WARNING, "Existing connection check failed, attempting to reconnect.", e);
+        }
+
+        SQLException lastFailure = null;
+        for (int attempt = 1; attempt <= retryAttempts; attempt++) {
+            try {
+                connection = DriverManager.getConnection(jdbcUrl, username, password);
+                final int attemptNumber = attempt;
+                LOGGER.log(Level.INFO, () ->
+                        String.format(Locale.ROOT, "Connected to database (attempt %d/%d).", attemptNumber, retryAttempts));
+                return connection;
+            } catch (SQLException ex) {
+                lastFailure = ex;
+                final int attemptNumber = attempt;
+                LOGGER.log(Level.WARNING, ex, () ->
+                        String.format(Locale.ROOT, "Failed to connect (attempt %d/%d).", attemptNumber, retryAttempts));
+                sleepQuietly(retryDelay);
+            }
+        }
+
+        throw new IllegalStateException(
+                String.format(Locale.ROOT, "Unable to establish database connection after %d attempts.", retryAttempts),
+                lastFailure);
+    }
+
+    /**
+     * Retrieves the current connection, connecting if one is not already available.
+     */
+    public synchronized Connection getConnection() {
+        return connect();
+    }
+
+    /**
+     * Indicates whether a live connection is currently held.
+     */
+    public synchronized boolean isConnected() {
+        try {
+            return connection != null && !connection.isClosed();
+        } catch (SQLException e) {
+            LOGGER.log(Level.FINE, "isConnected check failed.", e);
+            return false;
+        }
+    }
+
+    /**
+     * Closes the managed connection if one exists.
+     */
+    @Override
+    public synchronized void close() {
+        if (connection == null) {
+            return;
+        }
+
+        try {
+            if (!connection.isClosed()) {
+                connection.close();
+                LOGGER.info("Database connection closed.");
+            }
+        } catch (SQLException e) {
+            LOGGER.log(Level.WARNING, "Error closing database connection.", e);
+        } finally {
+            connection = null;
+        }
+    }
+
+    private static void sleepQuietly(Duration delay) {
+        if (delay.isZero() || delay.isNegative()) {
+            return;
+        }
+
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Retry interrupted while waiting to reconnect.", e);
+        }
+    }
+
+    private static String envOrDefault(String key, String fallback) {
+        String value = System.getenv(key);
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+
+    private static int parsePositiveInt(String key, int fallback) {
+        String raw = System.getenv(key);
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+
+        try {
+            int parsed = Integer.parseInt(raw);
+            if (parsed < 1) {
+                throw new IllegalArgumentException();
+            }
+            return parsed;
+        } catch (IllegalArgumentException ex) {
+            LOGGER.log(Level.WARNING, () ->
+                    String.format(Locale.ROOT,
+                            "Invalid value '%s' for %s. Using fallback %d.", raw, key, fallback));
+            return fallback;
+        }
+    }
+
+    private static long parsePositiveLong(String key, long fallback) {
+        String raw = System.getenv(key);
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+
+        try {
+            long parsed = Long.parseLong(raw);
+            if (parsed < 1) {
+                throw new IllegalArgumentException();
+            }
+            return parsed;
+        } catch (IllegalArgumentException ex) {
+            LOGGER.log(Level.WARNING, () ->
+                    String.format(Locale.ROOT,
+                            "Invalid value '%s' for %s. Using fallback %d.", raw, key, fallback));
+            return fallback;
+        }
+    }
+
+    private static String resolveJdbcUrl() {
+        String directUrl = System.getenv("DB_URL");
+        if (directUrl != null && !directUrl.isBlank()) {
+            return directUrl;
+        }
+
+        String host = envOrDefault("DB_HOST", "db");
+        String port = envOrDefault("DB_PORT", "3306");
+        String database = envOrDefault("DB_NAME", "world");
+        String options = envOrDefault("DB_OPTIONS", "allowPublicKeyRetrieval=true&useSSL=false");
+
+        String normalisedOptions = options.isBlank()
+                ? ""
+                : (options.startsWith("?") ? options : "?" + options);
+
+        return String.format(Locale.ROOT, "jdbc:mysql://%s:%s/%s%s", host, port, database, normalisedOptions);
+    }
+
+    private static void loadDriverIfRequired() {
+        if (DRIVER_LOADED.compareAndSet(false, true)) {
+            try {
+                Class.forName("com.mysql.cj.jdbc.Driver");
+                LOGGER.fine("MySQL JDBC driver loaded.");
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException("Could not load SQL driver.", e);
+            }
+        }
+    }
+
+    /**
+     * Fluent builder for database connection managers.
+     */
+    public static final class Builder {
+        private String jdbcUrl = DEFAULT_JDBC_URL;
+        private String username = DEFAULT_USERNAME;
+        private String password = DEFAULT_PASSWORD;
+        private int retryAttempts = DEFAULT_RETRY_ATTEMPTS;
+        private Duration retryDelay = DEFAULT_RETRY_DELAY;
+
+        private Builder() {
+        }
+
+        public Builder withUrl(String jdbcUrl) {
+            this.jdbcUrl = Objects.requireNonNull(jdbcUrl, "jdbcUrl must not be null.");
+            return this;
+        }
+
+        public Builder withUsername(String username) {
+            this.username = Objects.requireNonNull(username, "username must not be null.");
+            return this;
+        }
+
+        public Builder withPassword(String password) {
+            this.password = Objects.requireNonNull(password, "password must not be null.");
+            return this;
+        }
+
+        public Builder withRetryAttempts(int retryAttempts) {
+            if (retryAttempts < 1) {
+                throw new IllegalArgumentException("retryAttempts must be >= 1.");
+            }
+            this.retryAttempts = retryAttempts;
+            return this;
+        }
+
+        public Builder withRetryDelay(Duration retryDelay) {
+            Objects.requireNonNull(retryDelay, "retryDelay must not be null.");
+            if (retryDelay.isNegative()) {
+                throw new IllegalArgumentException("retryDelay must not be negative.");
+            }
+            this.retryDelay = retryDelay;
+            return this;
+        }
+
+        public DatabaseConnectionManager build() {
+            return new DatabaseConnectionManager(this);
+        }
+    }
+}

--- a/src/test/java/com/napier/semGROUP4/DatabaseConnectionManagerTest.java
+++ b/src/test/java/com/napier/semGROUP4/DatabaseConnectionManagerTest.java
@@ -1,0 +1,42 @@
+package com.napier.semGROUP4;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class DatabaseConnectionManagerTest {
+
+    @Test
+    void connectFailsWithInvalidUrlAfterConfiguredAttempts() {
+        DatabaseConnectionManager manager = DatabaseConnectionManager.builder()
+                .withUrl("jdbc:mysql://127.0.0.1:65000/world?allowPublicKeyRetrieval=true&useSSL=false")
+                .withRetryAttempts(1)
+                .withRetryDelay(Duration.ZERO)
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, manager::connect);
+        assertTrue(exception.getCause() instanceof SQLException, "Expected root cause to be an SQLException.");
+    }
+
+    @Test
+    void closeDoesNotThrowWhenConnectionNeverOpened() {
+        DatabaseConnectionManager manager = DatabaseConnectionManager.builder()
+                .withRetryAttempts(1)
+                .withRetryDelay(Duration.ZERO)
+                .build();
+
+        assertDoesNotThrow(manager::close);
+    }
+
+    @Test
+    void builderRejectsInvalidRetryAttempts() {
+        DatabaseConnectionManager.Builder builder = DatabaseConnectionManager.builder();
+
+        assertThrows(IllegalArgumentException.class, () -> builder.withRetryAttempts(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated DatabaseConnectionManager with configurable retries and environment-driven settings
- refactor App to rely on the helper and manage the connection lifecycle safely
- add JUnit Jupiter plus unit tests covering failure handling and builder validation

## Testing
- mvn -q test

## Notes
- Maven installed locally via Homebrew to execute the test suite
- Invalid-URL test intentionally logs a single warning while verifying retry failure handling

Fixes #23